### PR TITLE
DM-17753 Update Firefly notebook for jupyter_firefly_extensions

### DIFF
--- a/Firefly.ipynb
+++ b/Firefly.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# Firefly Visualization Demo\n",
     "\n",
-    "This notebook is intended to demonstrate the [Firefly](https://mospace.umsystem.edu/xmlui/handle/10355/5346) interactive interface for viewing image data. It also builds on the pedagogical explanations provided in [Getting started tutorial part 3](https://pipelines.lsst.io/getting-started/display.html) of the LSST Stack v15.0 documentation.\n",
+    "This notebook is intended to demonstrate the [Firefly](https://mospace.umsystem.edu/xmlui/handle/10355/5346) interactive interface for viewing image data. It also builds on the pedagogical explanations provided in [Getting started tutorial part 3](https://pipelines.lsst.io/getting-started/display.html) of the LSST Stack v16.0 documentation.\n",
     "\n",
     "This tutorial seeks to teach you about how to use the LSST Science Pipelines to inspect outputs from `processCcd.py` by displaying images and source catalogs in the Firefly image viewer. In doing so, you’ll be introduced to some of the LSST Science Pipelines’ Python APIs, including:\n",
     "\n",
@@ -23,7 +23,7 @@
     "\n",
     "This tutorial is meant to be run from the `jupyterhub` interface where the LSST stack is preinstalled. It assumes that the notebook is running a kernel with the `lsst_distrib` package set up.\n",
     "\n",
-    "We start by importing packages from the LSST stack, Firefly, and standard python libraries:"
+    "We start by importing packages from the LSST stack for data access and visualization."
    ]
   },
   {
@@ -34,15 +34,7 @@
    "source": [
     "# LSST stack imports\n",
     "from lsst.daf.persistence import Butler\n",
-    "import lsst.afw.display as afw_display\n",
-    "\n",
-    "# Firefly client imports\n",
-    "from firefly_client import FireflyClient\n",
-    "\n",
-    "# Standard libraries in support of Firefly display\n",
-    "from urllib.parse import urlparse, urlunparse, ParseResult\n",
-    "from IPython.display import IFrame, display, Markdown\n",
-    "import os"
+    "import lsst.afw.display as afw_display"
    ]
   },
   {
@@ -151,29 +143,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The display framework provides a uniform API for multiple display backends, including DS9, matplotlib, and LSST’s Firefly viewer. The default backend is `ds9`, but since we are working remotely on `jupyterhub` we would prefer to use the web-based Firefly display."
+    "The display framework provides a uniform API for multiple display backends, including DS9, matplotlib, and LSST’s Firefly viewer. The default backend is `ds9`, but since we are working remotely on `jupyterhub` we would prefer to use the web-based Firefly display. A [user guide](https://pipelines.lsst.io/v/daily/modules/lsst.display.firefly/index.html)  for `lsst.display.firefly` is available on the [pipelines.lsst.io site](https://pipelines.lsst.io/v/daily)."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now, we create a Firefly IFrame."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "my_channel = '{}_test_channel'.format(os.environ['USER'])\n",
-    "\n",
-    "afwDisplay.setDefaultBackend('firefly')\n",
-    "afw_display = afwDisplay.getDisplay(frame=1, \n",
-    "                                    name=my_channel)\n",
-    "\n",
-    "IFrame(afw_display.getClient().get_firefly_url(),800,600)"
+    "Now, we create a Firefly display."
    ]
   },
   {
@@ -183,8 +160,14 @@
    "outputs": [],
    "source": [
     "afwDisplay.setDefaultBackend('firefly')\n",
-    "afw_display = afwDisplay.getDisplay(frame=1, \n",
-    "                                    name=my_channel)"
+    "afw_display = afwDisplay.Display(frame=1)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In the LSST Science Platform Notebook aspect, a Firefly viewer tab appears. You may wish to drag it to the right side of the Jupyterlab area."
    ]
   },
   {
@@ -229,7 +212,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "afw_display.setMaskTransparency(60)"
+    "afw_display.setMaskTransparency(80)"
    ]
   },
   {
@@ -284,6 +267,13 @@
     "mask = calexp.getMask()\n",
     "for maskName, maskBit in mask.getMaskPlaneDict().items():\n",
     "    print('{}: {}'.format(maskName, afw_display.getMaskPlaneColor(maskName)))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In the Firefly viewer tab, the overlays button ![overlays button](http://irsa.ipac.caltech.edu/onlinehelp/finderchart/img/layers.png) on the toolbar gives you very detailed control over the mask planes, such as turning individual planes on and off, changing the color and adjusting the transparency. Mask transparency and colors can also be set using `afw.display` commands, for individual planes or for all."
    ]
   },
   {
@@ -392,7 +382,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can also use the Firefly client directly to make plots and add catalogs to the visualization.  First construct the `FireflyClient` object."
+    "We can also use the Firefly client directly to make plots and add catalogs to the visualization.  First retrieve the `FireflyClient` object."
    ]
   },
   {
@@ -408,7 +398,24 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We need a FITS file to pass to Firefly. This gives us the opportunity to play with the `src` table a bit. Let's select just the sources that were used to fit the PSF. "
+    "For uploading a table it is convenient to use the firefly_client.plot module. Import it and ensure it is using the same FireflyClient instance."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import firefly_client.plot as ffplt\n",
+    "ffplt.use_client(fc)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's select just the sources that were used to fit the PSF. "
    ]
   },
   {
@@ -425,7 +432,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now we persist the catalog to local storage and then upload it to Firefly."
+    "Upload a SourceCatalog to Firefly. By default, the catalog is shown in an interactive table viewer."
    ]
   },
   {
@@ -434,15 +441,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "psf_src.writeFits('psf_src.fits')\n",
-    "src_key = fc.upload_file('psf_src.fits')"
+    "tbl_id = ffplt.upload_table(psf_src, title='Source Catalog')"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Once the file is uploaded, we can have Firefly generate and display a scrollable table view widget.  Note that the label you give the table here, `tbl_id='src'`, is how you will refer to that dataset in future plots."
+    "Make a scatter plot."
    ]
   },
   {
@@ -451,66 +457,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "status = fc.show_table(src_key, tbl_id='src', page_size=1000)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "First we specify several style options for the plot."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "layout1 = dict(\n",
-    "               title='test ap flux/model mag vs. log(ap flux)', \n",
-    "               xaxis=dict(title='Model'), \n",
-    "               yaxis=dict(title='Ap/Model')\n",
-    "              )"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Now we specify the data to plot. Note the reference to `'src'`.  That allows for columnar math in the construction of the plot."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "trace1 = dict(\n",
-    "              tbl_id='src', \n",
-    "              x='tables::base_CircularApertureFlux_12_0_flux/base_GaussianFlux_flux',\n",
-    "              y='tables::log10(base_CircularApertureFlux_12_0_flux)',\n",
-    "              mode='markers',\n",
-    "              type='scatter',\n",
-    "              marker=dict(size=4)\n",
-    "             )"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Finally we can send the plot to the visualization canvas."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "status = fc.show_chart(layout=layout1, data=[trace1])"
+    "ffplt.scatter(x_col='base_CircularApertureFlux_12_0_flux/base_GaussianFlux_flux',\n",
+    "              y_col='log10(base_CircularApertureFlux_12_0_flux)',\n",
+    "              size=4,\n",
+    "              color='blue',\n",
+    "              title='test ap flux/model mag vs. log(ap flux)',\n",
+    "              xlabel='Model',\n",
+    "              ylabel='Ap/Model')"
    ]
   },
   {

--- a/Firefly.ipynb
+++ b/Firefly.ipynb
@@ -34,7 +34,7 @@
    "source": [
     "# LSST stack imports\n",
     "from lsst.daf.persistence import Butler\n",
-    "import lsst.afw.display as afw_display"
+    "import lsst.afw.display as afwDisplay"
    ]
   },
   {
@@ -127,23 +127,7 @@
    "source": [
     "## Create a Display\n",
     "\n",
-    "To display the `calexp` you will use the LSST `afwDisplay` framework, which is imported as:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import lsst.afw.display as afwDisplay"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "The display framework provides a uniform API for multiple display backends, including DS9, matplotlib, and LSST’s Firefly viewer. The default backend is `ds9`, but since we are working remotely on `jupyterhub` we would prefer to use the web-based Firefly display. A [user guide](https://pipelines.lsst.io/v/daily/modules/lsst.display.firefly/index.html)  for `lsst.display.firefly` is available on the [pipelines.lsst.io site](https://pipelines.lsst.io/v/daily)."
+    "To display the `calexp` you will use the LSST `afwDisplay` framework. It provides a uniform API for multiple display backends, including DS9, matplotlib, and LSST’s Firefly viewer. The default backend is `ds9`, but since we are working remotely on `jupyterhub` we would prefer to use the web-based Firefly display. A [user guide](https://pipelines.lsst.io/v/daily/modules/lsst.display.firefly/index.html)  for `lsst.display.firefly` is available on the [pipelines.lsst.io site](https://pipelines.lsst.io/v/daily)."
    ]
   },
   {


### PR DESCRIPTION
With the Firefly extension for Jupyterlab deployed in the LSST Science Platform Notebook Aspect, the startup of Firefly can be considerably simplified. Uploading a table and making a scatter plot is also easier with the `firefly_client.plot` convenience module.

* Simplify imports and the creation of the Firefly Display
* Streamline the table upload and plot at the end
* Minor improvements to Markdown cells