### PR TITLE
Demo notebook using aioinflux to access DM-EFD data

### DIFF
--- a/experiments/Accessing_DM-EFD_data.ipynb
+++ b/experiments/Accessing_DM-EFD_data.ipynb
@@ -1,0 +1,212 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Accessing DM-EFD data\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In this notebook we demonstrate how to extract data from the DM-EFD using [aioinflux](https://aioinflux.readthedocs.io/en/stable/index.html), a Python client for InfluxDB, and proceed with data analysis using Pandas dataframes. \n",
+    "\n",
+    "This is complementaty to the [Chronograf](https://test-chronograf-efd.lsst.codes) interface which we use for time-series visualization.\n",
+    "\n",
+    "In addition to `aioinflux`, you'll need to install `pandas`, `numpy` and `matplotlib` to run this notebook."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import aioinflux\n",
+    "import getpass"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We'll access the DM-EFD instance deployed at the AuxTel lab in Tucson. You need to be on site or connected to the NOAO VPN. \n",
+    "\n",
+    "If you are familiar with the AuxTel lab environment, you might be able to authenticate using the generic `saluser`. Ping me at Slack (`@afausti`) if you have any problem."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "username = \"saluser\"\n",
+    "password = getpass.getpass(f\"Password for {username}:\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The following configures the `aioinflux` Python client to connect to the DM-EFD InfluxDB instance. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "client = aioinflux.InfluxDBClient(host='test-influxdb-efd.lsst.codes', \n",
+    "                                  port='443', \n",
+    "                                  ssl=True, \n",
+    "                                  username=username, \n",
+    "                                  password=password,\n",
+    "                                  db='efd')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can configure the output to be a Pandas dataframe, which is very convenient for data analysis."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 86,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "client.output = 'dataframe'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Listing topics\n",
+    "Topics are mapped to [InfluxDB measurements](https://docs.influxdata.com/influxdb/v1.7/concepts). The following query simply lists all topics in the InfluxDB `efd` database:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "topics = await client.query('SHOW MEASUREMENTS')\n",
+    "topics"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Querying topic data\n",
+    "[InfluxQL](https://docs.influxdata.com/influxdb/v1.7/query_language/spec/), the influxDB query language, is very similar to SQL."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = await client.query('SELECT * FROM \"efd\".\"autogen\".\"lsst.sal.ATCamera.wreb\"')\n",
+    "df.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "At this point you can use [Pandas](https://pandas.pydata.org/pandas-docs/stable/reference/index.html) to analyze the data."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df.plot(y='ccdTemp0')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ccdTemp01h = df['ccdTemp0'].resample('15min').mean()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ccdTemp01h.plot()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df.plot.scatter(x='temp1', y='temp2')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Querying annotations"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In Chronograf, you can annotate the time-series to mark interesting events or features in the data. These annotations are saved in the `chronograf` database and can also be queried."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = await client.query('SELECT * FROM \"chronograf\".\"autogen\".\"annotations\"')\n",
+    "df['text']"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "venv",
+   "language": "python",
+   "name": "venv"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
We propose to use `aioinflux` a new Python client for InfluxDB which has several advantages over `influxdb-python`. See https://aioinflux.readthedocs.io/en/stable/usage.html#

In this notebook, we configure the client to access data from the DM-EFD deployment at the AuxTel lab and show simple analysis using Pandas dataframes.