### PR TITLE
Sub out LsstDaskClient for native Client

### DIFF
--- a/experiments/DASK-notebooks/gaia_all_sky.ipynb
+++ b/experiments/DASK-notebooks/gaia_all_sky.ipynb
@@ -81,7 +81,7 @@
    "outputs": [],
    "source": [
     "_ = cluster.scale_up(15)\n",
-    "client = LSSTDaskClient(cluster, overall_timeout=3600)\n",
+    "client = Client(cluster, overall_timeout=3600)\n",
     "client"
    ]
   },


### PR DESCRIPTION
The current implementation of the backoff code trips an exception in the sync method in `dask.distributed`.  This will test whether the native client avoids this.