### PR TITLE
[DM-23646] Add additional token debugging

### DIFF
--- a/token-info.ipynb
+++ b/token-info.ipynb
@@ -1,6 +1,14 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "First, analyze the raw token.\n",
+    "This does not validate the signature, just takes the JSON apart and looks at the contents."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -31,6 +39,7 @@
     "print(\"Your name is\", token_dict['name'])\n",
     "print(\"Your uid is\", token_dict['uid'])\n",
     "print(\"Your uid number is\", token_dict['uidNumber'])\n",
+    "print(\"The token issuer is\", token_dict['iss'])\n",
     "\n",
     "iat = time.gmtime(int(token_dict['iat']))\n",
     "print(\"Your token was issued at UTC:\", time.asctime(iat))\n",
@@ -50,6 +59,30 @@
     "if current_time > exp:\n",
     "    logging.error(\"Your token is expired!\")"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now, try to gather some additional information from the token issuer, including verifying the token."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "from urllib.parse import urljoin\n",
+    "\n",
+    "import requests\n",
+    "\n",
+    "analyze_url = urljoin(token_dict['iss'], '/auth/analyze')\n",
+    "r = requests.post(analyze_url, data={'token': token})\n",
+    "data = r.json()\n",
+    "print(json.dumps(data, indent=4))"
+   ]
   }
  ],
  "metadata": {
@@ -68,7 +101,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.8"
+   "version": "3.8.2"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Use the new /auth/analyze route on the issuer to further analyze
the token, including checking its signature and validity in the
same way that the authorization service does so.