### PR TITLE
Add a check to make sure we are on the right platform

### DIFF
--- a/token-info.ipynb
+++ b/token-info.ipynb
@@ -78,10 +78,14 @@
     "\n",
     "import requests\n",
     "\n",
-    "analyze_url = urljoin(token_dict['iss'], '/auth/analyze')\n",
-    "r = requests.post(analyze_url, data={'token': token})\n",
-    "data = r.json()\n",
-    "print(json.dumps(data, indent=4))"
+    "# Only run on int as that's the only place the analyze endpoint exists\n",
+    "if 'lsst-lsp-int' in os.environ['EXTERNAL_URL']:\n",
+    "    analyze_url = urljoin(token_dict['iss'], '/auth/analyze')\n",
+    "    r = requests.post(analyze_url, data={'token': token})\n",
+    "    data = r.json()\n",
+    "    print(json.dumps(data, indent=4))\n",
+    "else:\n",
+    "    logging.info('Not on a platform that supports the analyze endpoint.')"
    ]
   }
  ],
@@ -101,7 +105,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.2"
+   "version": "3.6.8"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Currently, the analyze endpoint is only available on the int platform.
When it is deployed at stable, we will loosen the check.