### PR TITLE
DM-24761: Switch backing data registry

### DIFF
--- a/Firefly.ipynb
+++ b/Firefly.ipynb
@@ -52,7 +52,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "datadir = '/project/shared/data/Twinkles_subset/output_data_v2'\n",
+    "datadir = '/datasets/hsc/repo/rerun/RC/w_2020_14/DM-24359-sfm'\n",
     "butler = Butler(datadir)"
    ]
   },
@@ -60,7 +60,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The `Butler` client reads from the data repository specified with the inputs argument. In this specific case, the data were downloaded from: [here](https://lsst-web.ncsa.illinois.edu/~krughoff/data/twinkles_subset.tar.gz).  See the `README.txt` in `/project/shared/data/Twinkles_subset` for more info."
+    "The `Butler` client reads from the data repository specified with the input data path.  This is a rerun of some HSC data that is stored for posterity."
    ]
   },
   {
@@ -75,7 +75,7 @@
     "\n",
     "Data IDs let you reference specific instances of a dataset. On the command line you select data IDs with `--id` arguments, filtering by keys like `visit`, `raft`, `ccd`, and `filter`.\n",
     "\n",
-    "Now, use the `Butler` client to find what data IDs are available for the `calexp` dataset type:\n",
+    "Now, use the `Butler` client to find what data IDs are available for the `raw` dataset type:\n",
     "\n"
    ]
   },
@@ -85,14 +85,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "butler.queryMetadata('calexp', ['visit', 'raft', 'sensor'], dataId={'filter': 'r'})"
+    "results = butler.queryMetadata('raw', ['visit', 'ccd'], dataId={'filter': 'HSC-R'})\n",
+    "results[:50]"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The printed output is a list of `(visit, raft, ccd)` key tuples for all data IDs where the filter key is the LSST r band. "
+    "The printed output is a list of `(visit, ccd)` key tuples for all data IDs where the filter key is the HST-R band. "
    ]
   },
   {
@@ -101,7 +102,7 @@
    "source": [
     "## Get an exposure through the Butler\n",
     "\n",
-    "Knowing a specific data ID, let’s get the dataset with the `Butler` client’s get method:"
+    "Let’s get the dataset with the `Butler` client’s get method.  Note that the previous cell just tells you what data were ingested not what data were processed.  By inspection, the following data id was both ingested and processed."
    ]
   },
   {
@@ -110,7 +111,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "dataId = {'filter': 'r', 'raft': '2,2', 'sensor': '1,1', 'visit': 235}\n",
+    "# Not all data were processed, so pick this one that does exist\n",
+    "dataId = {'filter': 'HSC-R', 'ccd': 50, 'visit': 1202}\n",
     "calexp = butler.get('calexp', **dataId)"
    ]
   },
@@ -127,7 +129,7 @@
    "source": [
     "## Create a Display\n",
     "\n",
-    "To display the `calexp` you will use the LSST `afwDisplay` framework. It provides a uniform API for multiple display backends, including DS9, matplotlib, and LSST’s Firefly viewer. The default backend is `ds9`, but since we are working remotely on `jupyterhub` we would prefer to use the web-based Firefly display. A [user guide](https://pipelines.lsst.io/v/daily/modules/lsst.display.firefly/index.html)  for `lsst.display.firefly` is available on the [pipelines.lsst.io site](https://pipelines.lsst.io/v/daily)."
+    "To display the `calexp` you will use the LSST `afwDisplay` framework. It provides a uniform API for multiple display backends, including DS9, matplotlib, and LSST’s Firefly viewer. The default backend is `ds9`, but since we are working remotely on `JupyterLab` we would prefer to use the web-based Firefly display. A [user guide](https://pipelines.lsst.io/v/daily/modules/lsst.display.firefly/index.html)  for `lsst.display.firefly` is available on the [pipelines.lsst.io](https://pipelines.lsst.io/v/daily) site."
    ]
   },
   {
@@ -151,7 +153,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In the LSST Science Platform Notebook aspect, a Firefly viewer tab appears. You may wish to drag it to the right side of the Jupyterlab area."
+    "In the Science Platform Notebook aspect, a Firefly viewer tab appears. You may wish to drag it to the right side of the JupyterLab area to create two side by side panes, one with the notebook and one with the display."
    ]
   },
   {
@@ -176,7 +178,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "As soon as you execute the command a single simulated, calibrated LSST exposure, the `{'filter': 'r', 'raft': '2,2', 'sensor': '1,1', 'visit': 235}` data ID, should appear in the Firefly browser window.\n",
+    "As soon as you execute the command a single calibrated HSC exposure for the `{'filter': 'HSC-R', 'ccd': 50, 'visit': 1202}` data ID should appear in the Firefly `JupyterLab` tab.\n",
     "\n",
     "Notice that the image is overlaid with colorful regions. These are mask regions. Each color reflects a different mask bit that correspond to detections and different types of detector artifacts. You’ll learn how to interpret these colors later, but first you’ll likely want to adjust the image display."
    ]
@@ -214,7 +216,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "afw_display.scale(\"asinh\", -1, 30)"
+    "afw_display.scale(\"asinh\", -5, 20)"
    ]
   },
   {
@@ -316,7 +318,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now we’ll overplot sources from the `src` table onto the image display using the Display’s `dot` method for plotting markers. `Display.dot` plots markers individually, so you’ll need to iterate over rows in the `SourceTable`. Next we display the first 100 sources. We limit the number of sources since plotting the whole catalog is a serial process and takes some time. Because of this, it is more efficient to send a batch of updates to the display, so we enclose the loop in a `display.Buffering` context, like this:"
+    "Now we’ll overplot sources from the `src` table onto the image display using the Display’s `dot` method for plotting markers. `Display.dot` plots markers individually, so you’ll need to iterate over rows in the `SourceTable`.  It is more efficient to send a batch of updates to the display, so we enclose the loop in a `display.Buffering` context, like this:"
    ]
   },
   {
@@ -328,13 +330,6 @@
     "with afw_display.Buffering():\n",
     "    for record in src:\n",
     "        afw_display.dot('o', record.getX(), record.getY(), size=20, ctype='orange')"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Note that the first 100 sources are preferentially located at the bottom of the image. This spatial ordering is likely imprinted by the source detection algorithm; however, it could change due to parallelization. The units o the `size` parameter are believed to be pixels."
    ]
   },
   {
@@ -399,7 +394,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Let's select just the sources that were used to fit the PSF. "
+    "Let's select just the sources that were used in fitting the PSF. "
    ]
   },
   {
@@ -408,8 +403,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "psf_src = src[src['calib_psfUsed']]\n",
-    "print(src['calib_psfUsed'])"
+    "psf_src = src[src['calib_psf_used']]\n",
+    "print(src['calib_psf_used'])"
    ]
   },
   {
@@ -441,8 +436,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ffplt.scatter(x_col='base_CircularApertureFlux_12_0_flux/base_GaussianFlux_flux',\n",
-    "              y_col='log10(base_CircularApertureFlux_12_0_flux)',\n",
+    "ffplt.scatter(x_col='base_CircularApertureFlux_12_0_instFlux/base_GaussianFlux_instFlux',\n",
+    "              y_col='log10(base_CircularApertureFlux_12_0_instFlux)',\n",
     "              size=4,\n",
     "              color='blue',\n",
     "              title='test ap flux/model mag vs. log(ap flux)',\n",
@@ -490,9 +485,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.6"
+   "version": "3.7.6"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
The old Twinkles repository finally got too old and broke
when the obs_lsstSim package was removed from the stack.

This moves to using a much newer HSC rerun.