### PR TITLE
[DM-26279] Example notebook to access EFD Parquet files from S3

### DIFF
--- a/experiments/Access_EFD_Parquet_files_from_S3.ipynb
+++ b/experiments/Access_EFD_Parquet_files_from_S3.ipynb
@@ -6,6 +6,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import os\n",
     "import boto3\n",
     "import botocore\n",
     "import pyarrow.parquet as pq\n",
@@ -17,7 +18,7 @@
    "metadata": {},
    "source": [
     "## Download a Parquet file from S3\n",
-    "See https://kafka-connect-manager.lsst.io/ for more information on the S3 Sink connector and references on it. For this example the S3 Sink connector is configure to partition data by time on an hourly basis."
+    "See https://kafka-connect-manager.lsst.io/ for more information on the S3 Sink connector."
    ]
   },
   {
@@ -26,9 +27,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "BUCKET_NAME = \"efd-sandbox.data\"\n",
-    "KEY = \"topics/example-002-aggregated/year=2020/month=08/day=06/hour=22/example-002-aggregated+0+0000022314.snappy.parquet\"\n",
-    "#KEY = \"topics/example-000-aggregated/year=2020/month=08/day=06/hour=16/example-000-aggregated+0+0000000177.snappy.parquet\""
+    "BUCKET_NAME = \"efd-sandbox.data\""
    ]
   },
   {
@@ -45,7 +44,62 @@
    "outputs": [],
    "source": [
     "s3 = boto3.resource('s3')\n",
-    "s3.Bucket(BUCKET_NAME).download_file(KEY, 'example-002-aggregated+0+0000022314.snappy.parquet')"
+    "bucket = s3.Bucket(BUCKET_NAME)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In this example the S3 Sink connector is configured to partition data by time on an hourly basis. The following helps to construct the path to find the files on S3."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "topic = \"example-002-aggregated\"\n",
+    "year = \"2020\"\n",
+    "month = \"08\"\n",
+    "day = \"07\"\n",
+    "hour = \"22\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for obj in bucket.objects.filter(Prefix=f\"topics/{topic}/year={year}/month={month}/day={day}/hour={hour}\"):\n",
+    "    print(f\"{bucket.name}:{obj.key}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The S3 Sink connector is configured to invoke file commits to S3 every 10 minutes (see the `rotate_interval_ms` configuration setting)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The object key in S3 is the complete file path. Here we download one of the files."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "KEY = \"topics/example-002-aggregated/year=2020/month=08/day=07/hour=21/example-002-aggregated+0+0000097683.snappy.parquet\"\n",
+    "FILE = os.path.basename(KEY)\n",
+    "bucket.download_file(KEY, FILE)"
    ]
   },
   {
@@ -61,7 +115,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "example_002_aggregated = pq.read_table('example-002-aggregated+0+0000022314.snappy.parquet')"
+    "example_002_aggregated = pq.read_table(FILE)"
    ]
   },
   {

--- a/experiments/Access_EFD_Parquet_files_from_S3.ipynb
+++ b/experiments/Access_EFD_Parquet_files_from_S3.ipynb
@@ -7,8 +7,11 @@
    "outputs": [],
    "source": [
     "import os\n",
+    "import io\n",
     "import boto3\n",
-    "import pyarrow.parquet as pq"
+    "import pandas as pd\n",
+    "import pyarrow.parquet as pq\n",
+    "%matplotlib widget"
    ]
   },
   {
@@ -63,7 +66,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In this example the S3 Sink connector is configured to partition data by time on an hourly basis. The following helps to construct the path to find the files on S3."
+    "In this example the S3 Sink connector is configured to partition data by time on an hourly basis. The following helps to construct the path to find the Parquet files on S3."
    ]
   },
   {
@@ -80,12 +83,23 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We use the `bucket.download_fileobj()` method to download the Parquet files into a buffer, and then Pyarrow to read the files and convert and append them to a Pandas dataframe."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
+    "df = pd.DataFrame()\n",
     "for obj in bucket.objects.filter(Prefix=f\"topics/{topic}/year={year}/month={month}/day={day}/hour={hour}\"):\n",
+    "    buffer = io.BytesIO()\n",
+    "    bucket.download_fileobj(obj.key, buffer)\n",
+    "    df = df.append(pq.read_table(buffer).to_pandas())\n",
     "    print(f\"{bucket.name}:{obj.key}\")"
    ]
   },
@@ -93,14 +107,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The S3 Sink connector is configured to invoke file commits to S3 every 10 minutes (see the `rotate_interval_ms` configuration setting), thus you should see 6 files in this path."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "The object key in S3 is the complete file path. Here we download one of the files."
+    "The S3 Sink connector is configured to invoke file commits to S3 every 10 minutes (see the `rotate_interval_ms` configuration setting) that's why you see 6 files in this path."
    ]
   },
   {
@@ -109,50 +116,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "KEY = obj.key\n",
-    "KEY"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "FILE = os.path.basename(KEY)\n",
-    "bucket.download_file(KEY, FILE)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Use Pyarrow read the Parquet file "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "example_002_aggregated = pq.read_table(FILE)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Convert from Parquet to Pandas Dataframe"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "df = example_002_aggregated.to_pandas()\n",
     "df.head()"
    ]
   },

--- a/experiments/Access_EFD_Parquet_files_from_S3.ipynb
+++ b/experiments/Access_EFD_Parquet_files_from_S3.ipynb
@@ -1,0 +1,123 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import boto3\n",
+    "import botocore\n",
+    "import pyarrow.parquet as pq\n",
+    "import pandas as pd"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Download a Parquet file from S3\n",
+    "See https://kafka-connect-manager.lsst.io/ for more information on the S3 Sink connector and references on it. For this example the S3 Sink connector is configure to partition data by time on an hourly basis."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "BUCKET_NAME = \"efd-sandbox.data\"\n",
+    "KEY = \"topics/example-002-aggregated/year=2020/month=08/day=06/hour=22/example-002-aggregated+0+0000022314.snappy.parquet\"\n",
+    "#KEY = \"topics/example-000-aggregated/year=2020/month=08/day=06/hour=16/example-000-aggregated+0+0000000177.snappy.parquet\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "S3 credentials are added to `~/.aws/credentials`file and the S3 region to the`~/.aws/config` file as explained here https://boto3.amazonaws.com/v1/documentation/api/latest/guide/credentials.html"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "s3 = boto3.resource('s3')\n",
+    "s3.Bucket(BUCKET_NAME).download_file(KEY, 'example-002-aggregated+0+0000022314.snappy.parquet')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Use Pyarrow read the Parquet file "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "example_002_aggregated = pq.read_table('example-002-aggregated+0+0000022314.snappy.parquet')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Convert from Parquet to Pandas Dataframe"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = example_002_aggregated.to_pandas()\n",
+    "df.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Plotting the aggregated stream"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "p = df.plot(x='time', y='mean_value1', c='white', figsize=(15,5))\n",
+    "p.fill_between(x='time', y1='min_value1', y2='max_value1', data=df)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "LSST",
+   "language": "python",
+   "name": "lsst"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/experiments/Access_EFD_Parquet_files_from_S3.ipynb
+++ b/experiments/Access_EFD_Parquet_files_from_S3.ipynb
@@ -1,25 +1,68 @@
 {
  "cells": [
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "cell_type": "markdown",
    "metadata": {},
-   "outputs": [],
    "source": [
-    "import os\n",
-    "import io\n",
-    "import boto3\n",
-    "import pandas as pd\n",
-    "import pyarrow.parquet as pq\n",
-    "%matplotlib widget"
+    "# Acessing EFD aggregated data"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Download a Parquet file from S3\n",
-    "See https://kafka-connect-manager.lsst.io/ for more information on the S3 Sink connector."
+    "Angelo Fausti, Simon Krughoff\n",
+    "\n",
+    "August 10, 2020\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Introduction\n",
+    "\n",
+    "In this notebook we show how to access data produced by the EFD aggregator. This was done as part of an internal demonstration of the EFD aggregator and used the EFD Sandox instance for this purpose."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## The EFD aggregated streams"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The EFD [aggregator](https://kafka-aggregator.lsst.io) is responsible for consuming the EFD data streams and produce a new set of aggregated streams which are then converted to Parquet files, partioned by time, and stored in an object store.\n",
+    "\n",
+    "To demonstrate the EFD aggregator we used the [aggregator example module](https://kafka-aggregator.lsst.io/configuration.html#example-module-configuration). \n",
+    "\n",
+    "In this experiment we initialize ten “example topics” and produce messages for them at 10Hz. For each field in the source topic the aggregator adds the following summary statistics `min`, `mean`, `median`, `stdev`, `max` and aggregate the messages in windows of 1s. See the the [aggregator configuration settings](https://kafka-aggregator.lsst.io/configuration.html#configuration-settings) for more details.\n",
+    "\n",
+    "A new set of aggretated topics is created in Kafka and we use the Kafka [S3 Sink Connector](https://docs.confluent.io/current/connect/kafka-connect-s3/) to write the data into Parquet files, in this example to Amazon S3."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Reading EFD Parquet files from S3\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import io\n",
+    "import boto3\n",
+    "import pandas as pd\n",
+    "import pyarrow.parquet as pq\n",
+    "%matplotlib widget"
    ]
   },
   {
@@ -35,7 +78,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The S3 credentials can be added to `~/.aws/credentials` file. They are stored in SQuaRE 1Password. Search for EFD AWS S3 credentials. The S3 region can be added to the`~/.aws/config` file.\n",
+    "The S3 credentials can be added to `~/.aws/credentials` file. They are stored in SQuaRE 1Password. Search for EFD AWS S3 credentials. The S3 region can be added to the `~/.aws/config` file.\n",
     "\n",
     "For example:\n",
     "```\n",
@@ -66,7 +109,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In this example the S3 Sink connector is configured to partition data by time on an hourly basis. The following helps to construct the path to find the Parquet files on S3."
+    "In this example the S3 Sink connector is configured to partition data by time on an hourly basis. The following helps to construct the path to find the Parquet files on S3 for one of the aggregated topics, in this example, `example-002-aggregated`."
    ]
   },
   {
@@ -86,7 +129,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We use the `bucket.download_fileobj()` method to download the Parquet files into a buffer, and then Pyarrow to read the files and convert and append them to a Pandas dataframe."
+    "We use the `bucket.download_fileobj()` method to download the Parquet files into a buffer, and then Pyarrow to read the files, convert and append them to a Pandas dataframe."
    ]
   },
   {

--- a/experiments/Access_EFD_Parquet_files_from_S3.ipynb
+++ b/experiments/Access_EFD_Parquet_files_from_S3.ipynb
@@ -8,9 +8,7 @@
    "source": [
     "import os\n",
     "import boto3\n",
-    "import botocore\n",
-    "import pyarrow.parquet as pq\n",
-    "import pandas as pd"
+    "import pyarrow.parquet as pq"
    ]
   },
   {
@@ -34,7 +32,21 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "S3 credentials are added to `~/.aws/credentials`file and the S3 region to the`~/.aws/config` file as explained here https://boto3.amazonaws.com/v1/documentation/api/latest/guide/credentials.html"
+    "The S3 credentials can be added to `~/.aws/credentials` file. They are stored in SQuaRE 1Password. Search for EFD AWS S3 credentials. The S3 region can be added to the`~/.aws/config` file.\n",
+    "\n",
+    "For example:\n",
+    "```\n",
+    "cat ~/.aws/credentials\n",
+    "[default]\n",
+    "aws_access_key_id = <the aws_access_key_id>\n",
+    "aws_secret_access_key = <the aws_secret_access_key>\n",
+    "```\n",
+    "and\n",
+    "```\n",
+    "cat ~/.aws/config \n",
+    "[default]\n",
+    "region=us-east-1\n",
+    "```"
    ]
   },
   {
@@ -81,7 +93,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The S3 Sink connector is configured to invoke file commits to S3 every 10 minutes (see the `rotate_interval_ms` configuration setting)."
+    "The S3 Sink connector is configured to invoke file commits to S3 every 10 minutes (see the `rotate_interval_ms` configuration setting), thus you should see 6 files in this path."
    ]
   },
   {
@@ -97,7 +109,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "KEY = \"topics/example-002-aggregated/year=2020/month=08/day=07/hour=21/example-002-aggregated+0+0000097683.snappy.parquet\"\n",
+    "KEY = obj.key\n",
+    "KEY"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "FILE = os.path.basename(KEY)\n",
     "bucket.download_file(KEY, FILE)"
    ]


### PR DESCRIPTION
A simple notebook showing how to access the EFD Parquet files from S3.

Note that for this example the S3 Sink connector was configured to partition the data on an hourly basis.

