### PR TITLE
Update catalog access nbs to run against 'small' qserv instance

### DIFF
--- a/LSST Catalog Access Tutorial.ipynb
+++ b/LSST Catalog Access Tutorial.ipynb
@@ -176,12 +176,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "results = service.search(\"SELECT * from TAP_SCHEMA.columns WHERE table_name = 'wise_00.allwise_p3as_mep'\")\n",
+    "results = service.search(\"SELECT * from TAP_SCHEMA.columns WHERE table_name = 'wise_01.allwise_p3as_mep'\")\n",
     "\n",
     "print(\"Column names for TAP_SCHEMA.columns are:\")\n",
     "print(results.fieldnames)\n",
     "\n",
-    "print(\"Columns that exist in wise_00.allwise_p3as_mep are:\")\n",
+    "print(\"Columns that exist in wise_01.allwise_p3as_mep are:\")\n",
     "results.to_table().show_in_notebook()"
    ]
   },
@@ -198,7 +198,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "results = service.search(\"SELECT column_name, description, unit FROM TAP_SCHEMA.columns WHERE table_name = 'wise_00.allwise_p3as_mep'\")\n",
+    "results = service.search(\"SELECT column_name, description, unit FROM TAP_SCHEMA.columns WHERE table_name = 'wise_01.allwise_p3as_mep'\")\n",
     "results.to_table().show_in_notebook()"
    ]
   },
@@ -232,7 +232,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "results = service.search(\"SELECT ra, decl FROM wise_00.allwise_p3as_mep WHERE CONTAINS(POINT('ICRS', ra, decl), CIRCLE('ICRS', 1.0, -1.0, .1)) = 1\", maxrec=10)\n",
+    "results = service.search(\"SELECT ra, dec FROM wise_01.allwise_p3as_mep WHERE CONTAINS(POINT('ICRS', ra, dec), CIRCLE('ICRS', 1.0, -1.0, .1)) = 1\", maxrec=10)\n",
     "results.to_table().show_in_notebook()"
    ]
   },
@@ -255,7 +255,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "results = service.search(\"SELECT ra, decl FROM wise_00.allwise_p3as_mep WHERE CONTAINS(POINT('ICRS', ra, decl), POLYGON('ICRS', .9, .9, 1, .9, 1, 1, .9, 1)) = 1\", maxrec=10)\n",
+    "results = service.search(\"SELECT ra, dec FROM wise_01.allwise_p3as_mep WHERE CONTAINS(POINT('ICRS', ra, dec), POLYGON('ICRS', .9, .9, 1, .9, 1, 1, .9, 1)) = 1\", maxrec=10)\n",
     "results.to_table().show_in_notebook()"
    ]
   },
@@ -272,7 +272,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "results = service.search(\"SELECT mjd, w1mpro_ep, w1sigmpro_ep, w2mpro_ep, w2sigmpro_ep FROM wise_00.allwise_p3as_mep WHERE source_id_mf = '2813m031_ac51-041856' AND mjd > 55450\")\n",
+    "results = service.search(\"SELECT mjd, w1mpro_ep, w1sigmpro_ep, w2mpro_ep, w2sigmpro_ep FROM wise_01.allwise_p3as_mep WHERE cntr_mf = 2813003101351041856 AND mjd > 55450\")\n",
     "results.to_table().show_in_notebook()"
    ]
   },
@@ -491,7 +491,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.8"
+   "version": "3.6.8"
   }
  },
  "nbformat": 4,

--- a/wise_color_color.ipynb
+++ b/wise_color_color.ipynb
@@ -60,7 +60,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "results = service.search(\"SELECT column_name, description, unit FROM TAP_SCHEMA.columns WHERE table_name = 'wise_00.allwise_p3as_mep'\")\n",
+    "results = service.search(\"SELECT column_name, description, unit FROM TAP_SCHEMA.columns WHERE table_name = 'wise_01.allwise_p3as_mep'\")\n",
     "results.to_table().show_in_notebook()"
    ]
   },
@@ -77,7 +77,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "results = service.search(\"SELECT w1mpro_ep, w2mpro_ep, w3mpro_ep FROM wise_00.allwise_p3as_mep WHERE CONTAINS(POINT('ICRS', ra, decl), CIRCLE('ICRS', 192.85, 27.13, .2)) = 1\")\n",
+    "results = service.search(\"SELECT w1mpro_ep, w2mpro_ep, w3mpro_ep FROM wise_01.allwise_p3as_mep WHERE CONTAINS(POINT('ICRS', ra, dec), CIRCLE('ICRS', 192.85, 27.13, .2)) = 1\")\n",
     "results.to_table()[0:50].show_in_notebook()"
    ]
   },


### PR DESCRIPTION
Minor changes:
* "wise00" to "wise01" and "decl" to "dec" throughout
* PK for time-series retrieval is now numeric "cntr_mf" instead of string "source_id_mf"